### PR TITLE
PO syntax and style and html attribute feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-html-gettext",
   "description": "Plugin to enable simple parsing of html files extracting inner text from tags with translate attribute set to yes. Output is pot file for gettext workflow",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "homepage": "https://github.com/matskm/grunt-html-gettext",
   "author": {
     "name": "Mat Martin",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-html-gettext",
   "description": "Plugin to enable simple parsing of html files extracting inner text from tags with translate attribute set to yes. Output is pot file for gettext workflow",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "homepage": "https://github.com/matskm/grunt-html-gettext",
   "author": {
     "name": "Mat Martin",
@@ -27,6 +27,7 @@
     "test": "grunt test"
   },
   "devDependencies": {
+    "html-entities": "^1.0.10",
     "grunt-contrib-jshint": "^0.9.2",
     "grunt-contrib-clean": "^0.5.0",
     "grunt-contrib-nodeunit": "^0.3.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-html-gettext",
   "description": "Plugin to enable simple parsing of html files extracting inner text from tags with translate attribute set to yes. Output is pot file for gettext workflow",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "homepage": "https://github.com/matskm/grunt-html-gettext",
   "author": {
     "name": "Mat Martin",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-html-gettext",
   "description": "Plugin to enable simple parsing of html files extracting inner text from tags with translate attribute set to yes. Output is pot file for gettext workflow",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "homepage": "https://github.com/matskm/grunt-html-gettext",
   "author": {
     "name": "Mat Martin",

--- a/tasks/html_gettext.js
+++ b/tasks/html_gettext.js
@@ -249,7 +249,7 @@ FilterHtmlHandler.prototype = {
   toPotFile: function(){
     var join_str = this._tr.join("");
 
-    var trim_str = join_str.replace(",","");
+    var trim_str = join_str;
 
     return trim_str;
   },

--- a/tasks/html_gettext.js
+++ b/tasks/html_gettext.js
@@ -382,31 +382,31 @@ FilterHtmlHandler.prototype = {
 
     // Translation inner text
     if(tflag_inner_text === true){
-      
-      
+ 
+ 
 
 
       //console.log("trans_comment: " + trans_comment);
-      
+ 
+
+      var trim_trans_comment = (trans_comment || "").replace("translatorcomment", "").trim();
+
+      if (trim_trans_comment.length > 0) {
+
+	var com_str = "#. " + trim_trans_comment + "\n";
+
+	this._tr.push(com_str);
+
+      }
+ 
+ 
 
       var line_num_str = "#: "+ path + ":" + this._n_count.toString() + "\n";
       this._tr.push(line_num_str);
-      
+ 
 
 
-      if(trans_comment != null){
-
-        var trim_trans_comment = trans_comment.replace("translatorcomment","");
-
-        var com_str = "#. " + trim_trans_comment + "\n";
-
-        this._tr.push(com_str);
-
-      }
-      
-      
-
-      var msgid_str = "msgid " + "\"" + s + "\"" + "\n";
+      var msgid_str = "msgid " + "\"" + s.replace(/\\(?!n)/g, '\\\\') + "\"" + "\n";
       this._tr.push(msgid_str);
 
       var msgstr_str = "msgstr " + "\"" + "\"" + "\n" + "\n";
@@ -477,7 +477,7 @@ module.exports = function(grunt) {
         // Do the parsing
         p.parse(src, filepath);
         // Return the result
-        return f.toPotFile();
+        return new Buffer(f.toPotFile());
 
       //}).join(grunt.util.normalizelf(options.separator));
       });
@@ -486,7 +486,7 @@ module.exports = function(grunt) {
       //src += options.punctuation;
 
       // Write the destination file.
-      grunt.file.write(f.dest, src);
+      grunt.file.write(f.dest, Buffer.concat(src));
 
       // Print a success message.
       grunt.log.writeln('File "' + f.dest + '" created.');

--- a/tasks/html_gettext.js
+++ b/tasks/html_gettext.js
@@ -123,7 +123,7 @@ SimpleHtmlParser.prototype = {
             }
 
 
-            return oThis.parseStartTag.apply(oThis, arguments);
+            return oThis.parseStartTag.apply(oThis, Array.prototype.concat(Array.prototype.slice.call(arguments, 0, 3), [path, oThis._comment_stash]));
           });
 
 
@@ -164,10 +164,10 @@ SimpleHtmlParser.prototype = {
     }
   },
 
-  parseStartTag:  function (sTag, sTagName, sRest)
+  parseStartTag:  function (sTag, sTagName, sRest, path, comment)
   {
     var attrs = this.parseAttributes(sTagName, sRest);
-    this.contentHandler.startElement(sTagName, attrs);
+    this.contentHandler.startElement(sTagName, attrs, path, comment);
   },
 
   parseStartTag_trans_flag:  function (sTag, sTagName, sRest)
@@ -256,7 +256,7 @@ FilterHtmlHandler.prototype = {
 
 // handler interface
 
-  startElement:   function (sTagName, attrs)
+  startElement:   function (sTagName, attrs, path, comment)
   {
     var ret_val = false;
 
@@ -289,6 +289,15 @@ FilterHtmlHandler.prototype = {
     }
 
     if(translate_flag === true){
+      if(path){
+        for (var i = 0; i < attrs.length; i++)
+        {
+          if(/^data-content/.test(attrs[i].name)){
+            this.characters(attrs[i].value, (attrs[i].value || "").trim().length > 0, path, comment);
+          }
+        }
+      }
+
       ret_val = true;
     }
 

--- a/tasks/html_gettext.js
+++ b/tasks/html_gettext.js
@@ -8,6 +8,8 @@
 
 'use strict';
 
+var Entities = require('html-entities').AllHtmlEntities;
+var entities = new Entities();
 
 
 // Parser follows
@@ -415,7 +417,7 @@ FilterHtmlHandler.prototype = {
  
 
 
-      var msgid_str = "msgid " + "\"" + s.replace(/\\(?!n)/g, '\\\\') + "\"" + "\n";
+      var msgid_str = "msgid " + "\"" + entities.decode(s).replace(/\\(?!n)/g, '\\\\') + "\"" + "\n";
       this._tr.push(msgid_str);
 
       var msgstr_str = "msgstr " + "\"" + "\"" + "\n" + "\n";


### PR DESCRIPTION
This corrects the issue with commas and aims, with its adjustments to comment order, trimming and escape characters, to produce output more similar to other gettext tools. This makes it easier to compare before and after running through tools like msgcat and msguniq.

Text is extracted from certain html attributes. This needs to be more configurable.
